### PR TITLE
Added type indicators to NbtDouble and NbtFloat

### DIFF
--- a/src/nbt/tags/NbtDouble.ts
+++ b/src/nbt/tags/NbtDouble.ts
@@ -22,13 +22,13 @@ export class NbtDouble extends NbtTag {
 
 	public override toString() {
 		if (Number.isInteger(this.value)) {
-			return this.value.toFixed(1)
+			return this.value.toFixed(1) + 'd'
 		}
 		return this.value.toString()
 	}
 
 	public override toPrettyString() {
-		return this.toString()
+		return this.toString() + 'd'
 	}
 
 	public override toSimplifiedJson() {

--- a/src/nbt/tags/NbtDouble.ts
+++ b/src/nbt/tags/NbtDouble.ts
@@ -22,9 +22,9 @@ export class NbtDouble extends NbtTag {
 
 	public override toString() {
 		if (Number.isInteger(this.value)) {
-			return this.value.toFixed(1) + 'd'
+			return this.value.toFixed(1)
 		}
-		return this.value.toString() + 'd'
+		return this.value.toString()
 	}
 
 	public override toPrettyString() {

--- a/src/nbt/tags/NbtDouble.ts
+++ b/src/nbt/tags/NbtDouble.ts
@@ -24,11 +24,11 @@ export class NbtDouble extends NbtTag {
 		if (Number.isInteger(this.value)) {
 			return this.value.toFixed(1) + 'd'
 		}
-		return this.value.toString()
+		return this.value.toString() + 'd'
 	}
 
 	public override toPrettyString() {
-		return this.toString() + 'd'
+		return this.toString()
 	}
 
 	public override toSimplifiedJson() {

--- a/src/nbt/tags/NbtFloat.ts
+++ b/src/nbt/tags/NbtFloat.ts
@@ -21,11 +21,11 @@ export class NbtFloat extends NbtTag {
 	}
 
 	public override toString() {
-		return this.value.toString()
+		return this.value.toString() + 'f'
 	}
 
 	public override toPrettyString() {
-		return this.toString()
+		return this.toString() + 'f'
 	}
 
 	public override toSimplifiedJson() {

--- a/src/nbt/tags/NbtFloat.ts
+++ b/src/nbt/tags/NbtFloat.ts
@@ -25,7 +25,7 @@ export class NbtFloat extends NbtTag {
 	}
 
 	public override toPrettyString() {
-		return this.toString() + 'f'
+		return this.toString()
 	}
 
 	public override toSimplifiedJson() {

--- a/test/nbt/tags/NbtFloat.test.ts
+++ b/test/nbt/tags/NbtFloat.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+import { NbtFloat } from '../../../src/nbt/index.js'
+
+describe('NbtFloat', () => {
+	it('toString', () => {
+		expect(new NbtFloat(4).toString()).toEqual('4f')
+
+		expect(new NbtFloat(2.35).toString()).toEqual('2.35f')
+	})
+})


### PR DESCRIPTION
Type safety is important for Minecraft to recognize float and double arrays properly.

![image](https://user-images.githubusercontent.com/28514936/223608832-b36bd099-fbdd-4af8-bc32-3ddce0ed5a06.png)
![image](https://user-images.githubusercontent.com/28514936/223608825-8c57fd78-8df8-4158-9a5d-f78df8f4243b.png)

Minecraft logs an error because it doesn't know that the numbers in this list are supposed to be floats.
```
java.util.concurrent.CompletionException: java.lang.IllegalArgumentException: Whilst parsing command on line 1: Can't insert TAG_Double into list of TAG_Int at position 246: ...cale:[1,1,<--[HERE]
```
