### PR TITLE
Performance optimization to Climate RTree search (same as vanilla)

### DIFF
--- a/benchmarks/index.ts
+++ b/benchmarks/index.ts
@@ -1,1 +1,2 @@
 import './math/index.js'
+// import './worldgen/index.js'

--- a/benchmarks/worldgen/MultiNoiseBiomeSource.ts
+++ b/benchmarks/worldgen/MultiNoiseBiomeSource.ts
@@ -1,0 +1,60 @@
+import * as b from 'benny'
+import type { DensityFunction } from '../../src'
+import { Climate, LegacyRandom, MultiNoiseBiomeSource } from '../../src'
+
+class DemoSampler implements Climate.Sampler{
+	public readonly temperature: DensityFunction
+	public readonly humidity: DensityFunction
+	public readonly continentalness: DensityFunction
+	public readonly erosion: DensityFunction
+	public readonly depth: DensityFunction
+	public readonly weirdness: DensityFunction
+
+	public random = new LegacyRandom(BigInt(1))
+
+	public last_temperature: number = 0
+	public last_humidity: number = 0
+	public last_continentalness: number = 0
+	public last_erosion: number = 0
+	public last_depth: number = 0
+	public last_weirdness: number = 0
+
+	sample(x: number, y: number, z: number): Climate.TargetPoint {
+		this.last_temperature += this.random.nextFloat() * 0.04 - 0.02
+		this.last_humidity += this.random.nextFloat() * 0.04 - 0.02
+		this.last_continentalness += this.random.nextFloat() * 0.04 - 0.02
+		this.last_erosion += this.random.nextFloat() * 0.04 - 0.02
+		this.last_depth += this.random.nextFloat() * 0.04 - 0.02
+		this.last_weirdness += this.random.nextFloat() * 0.04 - 0.02
+		return new Climate.TargetPoint(this.last_temperature, this.last_humidity, this.last_continentalness, this.last_erosion, this.last_depth, this.last_weirdness)
+	}
+}
+
+
+const MC_META = 'https://raw.githubusercontent.com/misode/mcmeta/data/'
+
+
+b.suite('MultiNoiseBiomeSource',
+	b.add('getBiome Vanilla', async () => {
+		const biome_source_json = (await (await fetch(`${MC_META}data/minecraft/dimension/overworld.json`)).json()).generator.biome_source
+		const biome_source = MultiNoiseBiomeSource.fromJson(biome_source_json)
+		var sampler = new DemoSampler()
+		biome_source.getBiome(0,0,0, sampler)
+
+		return () => {
+			biome_source.getBiome(0, 0, 0, sampler)
+		}
+	}),
+	b.add('getBiome Terralith', async () => {
+		const biome_source_json = (await (await fetch('https://raw.githubusercontent.com/Stardust-Labs-MC/Terralith/main/data/minecraft/dimension/overworld.json')).json()).generator.biome_source
+		const biome_source = MultiNoiseBiomeSource.fromJson(biome_source_json)
+		var sampler = new DemoSampler()
+		biome_source.getBiome(0,0,0, sampler)
+
+		return () => {
+			biome_source.getBiome(0, 0, 0, sampler)
+		}
+	}),
+	b.cycle(),
+	b.complete()
+)

--- a/benchmarks/worldgen/index.ts
+++ b/benchmarks/worldgen/index.ts
@@ -1,0 +1,1 @@
+import './MultiNoiseBiomeSource'

--- a/src/worldgen/biome/Climate.ts
+++ b/src/worldgen/biome/Climate.ts
@@ -146,6 +146,8 @@ export namespace Climate {
 		public static readonly CHILDREN_PER_NODE = 10
 		private readonly root: RNode<T>
 
+		private last_leaf: RLeaf<T> | null = null
+
 		constructor(points: [ParamPoint, () => T][]) {
 			if (points.length === 0) {
 				throw new Error('At least one point is required to build search tree')
@@ -227,8 +229,9 @@ export namespace Climate {
 			return f
 		}
 
-		public search(target: TargetPoint, distance: DistanceMetric<T>) {
-			const leaf = this.root.search(target.toArray(), distance)
+		public search(target: TargetPoint, distance: DistanceMetric<T>): T {
+			const leaf = this.root.search(target.toArray(), this.last_leaf, distance)
+			this.last_leaf = leaf
 			return leaf.thing()
 		}
 	}
@@ -236,7 +239,7 @@ export namespace Climate {
 	export abstract class RNode<T> {
 		constructor(public readonly space: Param[]) {}
 
-		public abstract search(values: number[], distance: DistanceMetric<T>): RLeaf<T>
+		public abstract search(values: number[], closest_leaf: RLeaf<T> | null, distance: DistanceMetric<T>): RLeaf<T>
 
 		public distance(values: number[]) {
 			let result = 0
@@ -260,14 +263,16 @@ export namespace Climate {
 			return space
 		}
 
-		search(values: number[], distance: DistanceMetric<T>): RLeaf<T> {
-			let dist = Infinity
-			let leaf: RLeaf<T> | null = null
+		search(values: number[], closest_leaf: RLeaf<T> | null, distance: DistanceMetric<T>): RLeaf<T> {
+			let dist = closest_leaf ? distance(closest_leaf, values) : Infinity
+			let leaf: RLeaf<T> | null = closest_leaf
 			for (const node of this.children) {
 				const d1 = distance(node, values)
 				if (dist <= d1) continue
-				const leaf2 = node.search(values, distance)
+				const leaf2 = node.search(values, leaf, distance)
+				if (leaf2 === null) continue
 				const d2 = node == leaf2 ? d1 : distance(leaf2, values)
+				if (d2 === 0) return leaf2
 				if (dist <= d2) continue
 				dist = d2
 				leaf = leaf2


### PR DESCRIPTION
Performance optimization in the search of the RTree for the MultiNoiseBiomeSource.

After having tried a different optimization with a Priority Queue, this is the same optimization that exists in the Minecraft code and consists of 2 parts:

1. The currently found closest Leaf is passed to all subsequent calls of search such that the search can be skipped if the node is farther away
2. The tree keeps track of the last result of the `search` call. In the subsequent call this node is passed as the the current closest Leaf to the search of the root node. As subsequent calls are often for areas close to each other this leaf quickly reduces the `dist` to a relatively small number, allowing the skipping of much larger parts of the search.

I've added a benchmark the simulates subsequent calls to similar areas (similar climate target) for the vanilla overworld as well as terralith. For some reason adding the benchmark to the suit makes the `fetch` fail. You can run the benchmark separately with `npx esno benchmarks/worldgen/MultiNoiseBiomeSource.ts`

Results:
|                    | Vanilla                | Terralith             |
|--------------------|------------------------|-----------------------|
| No Optimization    | 170 853 ops/s, ±35.02% | 16 933 ops/s, ±3.81%  |
| Optimization 1     | 207 923 ops/s, ±2.03%  | 67 333 ops/s, ±5.59%  |
| Optimization 1 & 2 | 447 931 ops/s, ±5.04%  | 316 174 ops/s, ±1.44% |

Of course optimization 2 relies on calls from similar areas and as such the performance improvement depends on how similar the calls are. My simulation might not accurately represent the real world generation, but I didn't want to load all the data that would be required to do the proper simulation.