### PR TITLE
Rendering improvements

### DIFF
--- a/src/render/ChunkBuilder.ts
+++ b/src/render/ChunkBuilder.ts
@@ -74,7 +74,7 @@ export class ChunkBuilder {
 				}
 				if (!mesh.isEmpty()) {	
 					this.finishChunkMesh(mesh, b.pos)
-					if (this.resources.getBlockFlags(b.state.getName())?.transparent){
+					if (this.resources.getBlockFlags(b.state.getName())?.semi_transparent){
 						chunk.transparentMesh.merge(mesh)
 					} else {
 						chunk.mesh.merge(mesh)

--- a/src/render/StructureRenderer.ts
+++ b/src/render/StructureRenderer.ts
@@ -70,7 +70,7 @@ type GridBuffers = {
 
 export type BlockFlags = {
 	opaque?: boolean,
-	transparent?: boolean,
+	semi_transparent?: boolean,
 	self_culling?: boolean,
 }
 

--- a/src/render/StructureRenderer.ts
+++ b/src/render/StructureRenderer.ts
@@ -59,15 +59,6 @@ const fsGrid = `
   }
 `
 
-
-
-
-type GridBuffers = {
-	position: WebGLBuffer,
-	color: WebGLBuffer,
-	length: number,
-}
-
 export type BlockFlags = {
 	opaque?: boolean,
 	semi_transparent?: boolean,

--- a/src/render/StructureRenderer.ts
+++ b/src/render/StructureRenderer.ts
@@ -68,8 +68,10 @@ type GridBuffers = {
 	length: number,
 }
 
-type BlockFlags = {
+export type BlockFlags = {
 	opaque?: boolean,
+	transparent?: boolean,
+	self_culling?: boolean,
 }
 
 export interface BlockFlagsProvider {


### PR DESCRIPTION
Includes 2 rendering improvements. Both are activated by new BlockFlags and don't change anything unless these flags are set on some blocks - making them fully backwards compatible.

1. Separate meshes for semi-transparent blocks: Blocks which have the `semi_transparent` flag set are added to a different mesh by the chunk builder. The `getMeshes` function returns the transparent meshes last, so that when rendering them in order, the transparent meshes are rendered last. This fixes the issue where solid blocks are not visible behind semi-transparent blocks.
2. Self-culling: The `self_culling` flag controls weather a block culls faces of itself when placed next itself. For vanilla, ResourceManagers can set this to true for all blocks except leaves.