### PR TITLE
Fixed missing multiplication in ShiftNoise.compute()

### DIFF
--- a/src/worldgen/DensityFunction.ts
+++ b/src/worldgen/DensityFunction.ts
@@ -529,7 +529,7 @@ export namespace DensityFunction {
 			super()
 		}
 		public compute(context: Context) {
-			return this.offsetNoise?.sample(context.x * 0.25, context.y * 0.25, context.z * 0.25) ?? 0
+			return (this.offsetNoise?.sample(context.x * 0.25, context.y * 0.25, context.z * 0.25) ?? 0) * 4
 		}
 		public maxValue() {
 			return (this.offsetNoise?.maxValue ?? 2) * 4 


### PR DESCRIPTION
A multiplication by 4 is missing from ShiftNoise.compute(), which causes excessive smoothness of biome generation.
After the fix it is consistent with cubiomes and Minecraft.

Before fix:
![before](https://github.com/user-attachments/assets/80cbea17-b8bd-4616-b05d-e30e48f02d42)

After fix:
![after](https://github.com/user-attachments/assets/704c0ec7-b148-4ce5-8d3f-57d5c38aea72)

