### PR TITLE
Fix banner upside down

### DIFF
--- a/src/render/SpecialRenderer.ts
+++ b/src/render/SpecialRenderer.ts
@@ -602,8 +602,8 @@ export namespace SpecialRenderers {
 				0: 'entity/banner_base',
 			}, [
 				{
-					from: [-2, -8, 9],
-					to: [18, 32, 10],
+					from: [-2, -8, 6],
+					to: [18, 32, 7],
 					faces: {
 						north: {uv: [0.25, 0.25, 5.25, 10.25], texture: '#0'},
 						east: {uv: [0, 0.25, 0.25, 10.25], texture: '#0'},


### PR DESCRIPTION
The banner is reversed before
game: ![44695119033ee05bd6839e83bd263a4e](https://github.com/user-attachments/assets/82288eee-7fff-47a8-b12e-0f470e5a1b58)
render: ![ec009b76af46df2fb4b530abdbe4a65f](https://github.com/user-attachments/assets/5760b658-c4c6-4c8b-8b32-1a071e6e207f)

new: ![image](https://github.com/user-attachments/assets/55a89aab-6c71-4214-b4d1-7b8e2edcf652)
structure: [banners.zip](https://github.com/user-attachments/files/19052355/banners.zip)

