### PR TITLE
Fix major rendering bug of semi-transparent blocks

### DIFF
--- a/src/render/StructureRenderer.ts
+++ b/src/render/StructureRenderer.ts
@@ -1,5 +1,4 @@
-import type { vec3 } from 'gl-matrix'
-import { mat4 } from 'gl-matrix'
+import { mat4, vec3 } from 'gl-matrix'
 import type { Identifier, StructureProvider } from '../core/index.js'
 import { BlockState } from '../core/index.js'
 import type { Color } from '../index.js'
@@ -212,8 +211,11 @@ export class StructureRenderer extends Renderer {
 		this.setTexture(this.atlasTexture)
 		this.prepareDraw(viewMatrix)
 
-		this.chunkBuilder.getMeshes().forEach(mesh => {
-			this.drawMesh(mesh, { pos: true, color: true, texture: true, normal: true })
+		this.chunkBuilder.getNonTransparentMeshes().forEach(mesh => {
+			this.drawMesh(mesh, { pos: true, color: true, texture: true, normal: true, sort: false })
+		})
+		this.chunkBuilder.getTransparentMeshes(this.extractCameraPositionFromView()).forEach(mesh => {
+			this.drawMesh(mesh, { pos: true, color: true, texture: true, normal: true, sort: true })
 		})
 	}
 
@@ -221,8 +223,11 @@ export class StructureRenderer extends Renderer {
 		this.setShader(this.colorShaderProgram)
 		this.prepareDraw(viewMatrix)
 
-		this.chunkBuilder.getMeshes().forEach(mesh => {
-			this.drawMesh(mesh, { pos: true, color: true, normal: true, blockPos: true })
+		this.chunkBuilder.getNonTransparentMeshes().forEach(mesh => {
+			this.drawMesh(mesh, { pos: true, color: true, normal: true, blockPos: true, sort: false })
+		})
+		this.chunkBuilder.getTransparentMeshes(this.extractCameraPositionFromView()).forEach(mesh => {
+			this.drawMesh(mesh, { pos: true, color: true, normal: true, blockPos: true, sort: true })
 		})
 	}
 


### PR DESCRIPTION
Related Issue: https://github.com/misode/deepslate/issues/54

Related PR:
- Chunked Buffer: https://github.com/misode/deepslate/pull/4
- Transparent Buffer: https://github.com/misode/deepslate/pull/31

Purpose: Mainly, this PR fixes issues when rendering multiple semi-transparent blocks stacked together.

How it's done:
- For transparent chunks, we need to sort all the meshes within it
- Since rendering is also chunk by chunk, we also need to sort all transparent chunks
- We can prove mathematically that only these two sortings are needed to ensure the correct depth buffer as long as fragments don't exceed block/chunk boundary

Specifically:
- `getMeshes()` is removed and replaced with `getTransparentMeshes(cameraPos: vec3)` and `getNonTransparentMeshes()`
- `drawColoredStructure` and `drawStructure` should change accordingly, and non-transparent chunks should be rendered first.

The result was tested on various chunk sizes and view angles. Feel free to reorganize my code.