### PR TITLE
Fix rendering bug for mesh index exceeding uint16 range (which is fairly common)

### DIFF
--- a/src/render/ChunkBuilder.ts
+++ b/src/render/ChunkBuilder.ts
@@ -85,19 +85,6 @@ export class ChunkBuilder {
 				console.error(`Error rendering block ${blockName}`, e)
 			}
 		}
-
-		if (!chunkPositions) {
-			this.chunks.forEach(x => x.forEach(y => y.forEach(chunk => {
-				chunk.mesh.rebuild(this.gl, { pos: true, color: true, texture: true, normal: true, blockPos: true })
-				// We don't sort the transparent mesh here, as we trust the user will pass sort=True when calling drawMesh() to prevent double sorting
-			})))
-		} else {
-			chunkPositions.forEach(chunkPos => {
-				const chunk = this.getChunk(chunkPos)
-				chunk.mesh.rebuild(this.gl, { pos: true, color: true, texture: true, normal: true, blockPos: true })
-				// We don't sort the transparent mesh here, as we trust the user will pass sort=True when calling drawMesh() to prevent double sorting
-			})
-		}
 	}
 
 	public getTransparentMeshes(cameraPos: vec3): Mesh[] {

--- a/src/render/ItemRenderer.ts
+++ b/src/render/ItemRenderer.ts
@@ -53,7 +53,6 @@ export class ItemRenderer extends Renderer {
 		mesh.merge(specialMesh)
 		mesh.transform(model.getDisplayTransform('gui'))
 		mesh.computeNormals()
-		mesh.rebuild(this.gl, { pos: true, color: true, texture: true, normal: true })
 		return mesh
 	}
 

--- a/src/render/Mesh.ts
+++ b/src/render/Mesh.ts
@@ -16,14 +16,41 @@ export class Mesh {
 	public linePosBuffer: WebGLBuffer | undefined
 	public lineColorBuffer: WebGLBuffer | undefined
 
+	public posBufferDirty = true
+	public colorBufferDirty = true
+	public textureBufferDirty = true
+	public normalBufferDirty = true
+	public blockPosBufferDirty = true
+	public indexBufferDirty = true
+
+	public linePosBufferDirty = true
+	public lineColorBufferDirty = true
+
 	constructor(
 		public quads: Quad[] = [],
 		public lines: Line[] = []
 	) {}
 
+	public setDirty(options: { quads?: boolean, lines?: boolean }) {
+		if (options.quads !== undefined) {
+			this.posBufferDirty = options.quads
+			this.colorBufferDirty = options.quads
+			this.textureBufferDirty = options.quads
+			this.normalBufferDirty = options.quads
+			this.blockPosBufferDirty = options.quads
+			this.indexBufferDirty = options.quads
+		}
+		if (options.lines) {
+			this.linePosBufferDirty = true
+			this.lineColorBufferDirty = true
+		}
+	}
+
 	public clear() {
 		this.quads = []
 		this.lines = []
+
+		this.setDirty({ quads: true, lines: true })
 		return this	
 	}
 
@@ -46,6 +73,8 @@ export class Mesh {
 	public merge(other: Mesh) {
 		this.quads = this.quads.concat(other.quads)
 		this.lines = this.lines.concat(other.lines)
+
+		this.setDirty({ quads: true, lines: true })
 		return this
 	}
 
@@ -55,6 +84,8 @@ export class Mesh {
 			Vertex.fromPos(new Vector(x2, y2, z2))
 		).setColor(color)
 		this.lines.push(line)
+
+		this.setDirty({ lines: true })
 		return this
 	}
 
@@ -74,6 +105,7 @@ export class Mesh {
 		this.addLine(x1, y2, z1, x2, y2, z1, color)
 		this.addLine(x1, y2, z2, x2, y2, z2, color)
 
+		this.setDirty({ lines: true })
 		return this
 	}
 
@@ -81,6 +113,8 @@ export class Mesh {
 		for (const quad of this.quads) {
 			quad.transform(transformation)
 		}
+
+		this.setDirty({ quads: true })
 		return this
 	}
 
@@ -89,6 +123,26 @@ export class Mesh {
 			const normal = quad.normal()
 			quad.forEach(v => v.normal = normal)
 		}
+	}
+
+	public split(): Mesh[] {
+		// Maximum number of quads per mesh, calculated so that:
+		// (number of vertices) = (quads * 4) and highest index (4*n - 1) remains <= 65535.
+		// Using the condition (quads * 4 + 3) <= 65536 leads to:
+		const maxQuads: number = Math.floor((65536 - 3) / 4);
+		
+		if (this.quads.length * 4 + 3 <= 65536) {
+			return [this];
+		}
+		
+		const meshes: Mesh[] = [];
+		for (let i: number = 0; i < this.quads.length; i += maxQuads) {
+			const chunk: Quad[] = this.quads.slice(i, i + maxQuads);
+			// For lines, we include lines only in the first split mesh.
+			const lines: Line[] = i === 0 ? this.lines : [];
+			meshes.push(new Mesh(chunk, lines));
+		}
+		return meshes;
 	}
 
 	public rebuild(gl: WebGLRenderingContext, options: { pos?: boolean, color?: boolean, texture?: boolean, normal?: boolean, blockPos?: boolean }) {
@@ -116,28 +170,47 @@ export class Mesh {
 			return rebuildBuffer(buffer, gl.ARRAY_BUFFER, new Float32Array(data))
 		}
 
-		if (options.pos) {
+		if (options.pos && this.posBufferDirty) {
 			this.posBuffer = rebuildBufferV(this.quads, this.posBuffer, v => v.pos.components())
+			this.posBufferDirty = false
+		}
+		if (options.pos && this.linePosBufferDirty) {
 			this.linePosBuffer = rebuildBufferV(this.lines, this.linePosBuffer, v => v.pos.components())
+			this.linePosBufferDirty = false
 		}
-		if (options.color) {
+		if (options.color && this.colorBufferDirty) {
 			this.colorBuffer = rebuildBufferV(this.quads, this.colorBuffer, v => v.color)
+			this.colorBufferDirty = false
+		}
+		if (options.color && this.lineColorBufferDirty) {
 			this.lineColorBuffer = rebuildBufferV(this.lines, this.lineColorBuffer, v => v.color)
+			this.lineColorBufferDirty = false
 		}
-		if (options.texture) {
+		if (options.texture && this.textureBufferDirty) {
 			this.textureBuffer = rebuildBufferV(this.quads, this.textureBuffer, v => v.texture)
+			this.textureBufferDirty = false
 		}
-		if (options.normal) {
+		if (options.normal && this.normalBufferDirty) {
 			this.normalBuffer = rebuildBufferV(this.quads, this.normalBuffer, v => v.normal?.components())
+			this.normalBufferDirty = false
 		}
-		if (options.blockPos) {
+		if (options.blockPos && this.blockPosBufferDirty) {
 			this.blockPosBuffer = rebuildBufferV(this.quads, this.blockPosBuffer, v => v.blockPos?.components())
+			this.blockPosBufferDirty = false
 		}
-		if (this.quads.length === 0) {
-			if (this.indexBuffer) gl.deleteBuffer(this.indexBuffer)
-			this.indexBuffer = undefined
-		} else {
-			this.indexBuffer = rebuildBuffer(this.indexBuffer, gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(this.quads.flatMap((_, i) => [4*i, 4*i + 1, 4*i + 2, i*4, 4*i + 2, 4*i + 3], true)))
+
+		if (this.indexBufferDirty) {
+			if (this.quads.length === 0) {
+				if (this.indexBuffer) gl.deleteBuffer(this.indexBuffer)
+				this.indexBuffer = undefined
+			  this.indexBufferDirty = false
+			} else {
+				if (this.quads.length * 4 + 3 > 65536) {
+					throw new Error('You got ' + this.quads.length * 4 + 3 + ' vertices, which is more than the max index of uint16 (65536)')
+				}
+				this.indexBuffer = rebuildBuffer(this.indexBuffer, gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(this.quads.flatMap((_, i) => [4*i, 4*i + 1, 4*i + 2, i*4, 4*i + 2, 4*i + 3], true)))
+				this.indexBufferDirty = false
+			}
 		}
 
 		return this

--- a/src/render/StructureRenderer.ts
+++ b/src/render/StructureRenderer.ts
@@ -1,5 +1,4 @@
-import type { vec3 } from 'gl-matrix'
-import { mat4 } from 'gl-matrix'
+import { mat4, vec3 } from 'gl-matrix'
 import type { Identifier, StructureProvider } from '../core/index.js'
 import { BlockState } from '../core/index.js'
 import type { Color } from '../index.js'
@@ -212,8 +211,11 @@ export class StructureRenderer extends Renderer {
 		this.setTexture(this.atlasTexture)
 		this.prepareDraw(viewMatrix)
 
-		this.chunkBuilder.getMeshes().forEach(mesh => {
-			this.drawMesh(mesh, { pos: true, color: true, texture: true, normal: true })
+		this.chunkBuilder.getNonTransparentMeshes().forEach(mesh => {
+			this.drawMesh(mesh, { pos: true, color: true, texture: true, normal: true, sort: false })
+		})
+		this.chunkBuilder.getTransparentMeshes(this.extractCameraPositionFromView()).forEach(mesh => {
+			this.drawMesh(mesh, { pos: true, color: true, texture: true, normal: true, sort: true })
 		})
 	}
 
@@ -221,8 +223,11 @@ export class StructureRenderer extends Renderer {
 		this.setShader(this.colorShaderProgram)
 		this.prepareDraw(viewMatrix)
 
-		this.chunkBuilder.getMeshes().forEach(mesh => {
-			this.drawMesh(mesh, { pos: true, color: true, normal: true, blockPos: true })
+		this.chunkBuilder.getNonTransparentMeshes().forEach(mesh => {
+			this.drawMesh(mesh, { pos: true, color: true, normal: true, blockPos: true, sort: false })
+		})
+		this.chunkBuilder.getTransparentMeshes(this.extractCameraPositionFromView()).forEach(mesh => {
+			this.drawMesh(mesh, { pos: true, color: true, normal: true, blockPos: true, sort: true })
 		})
 	}
 

--- a/src/render/StructureRenderer.ts
+++ b/src/render/StructureRenderer.ts
@@ -152,13 +152,12 @@ export class StructureRenderer extends Renderer {
 		for (let x = 1; x <= X; x += 1) mesh.addLine(x, 0, 0, x, 0, Z, c)
 		for (let z = 1; z <= Z; z += 1) mesh.addLine(0, 0, z, X, 0, z, c)
 
-		return mesh.rebuild(this.gl, { pos: true, color: true })
+		return mesh
 	}
 
 	private getOutlineMesh(): Mesh {
 		return new Mesh()
 			.addLineCube(0, 0, 0, 1, 1, 1, [1, 1, 1])
-			.rebuild(this.gl, { pos: true, color: true })
 	}
 
 	private getInvisibleBlocksMesh(): Mesh {
@@ -186,7 +185,7 @@ export class StructureRenderer extends Renderer {
 			}
 		}
 
-		return mesh.rebuild(this.gl, { pos: true, color: true })
+		return mesh
 	}
 
 	public drawGrid(viewMatrix: mat4) {

--- a/src/render/VoxelRenderer.ts
+++ b/src/render/VoxelRenderer.ts
@@ -133,9 +133,6 @@ export class VoxelRenderer extends Renderer {
 		if (!mesh.isEmpty()) {
 			meshes.push(mesh)
 		}
-		for (const mesh of meshes) {
-			mesh.rebuild(this.gl, { pos: true, color: true })
-		}
 		return meshes
 	}
 


### PR DESCRIPTION
Related Issues:
- https://github.com/misode/deepslate/issues/14
- https://github.com/misode/vscode-nbt/issues/78

Purpose: Mainly, this PR ensures all renderings are correct regardless of what chunkSize is used for rendering.

How it's done:
- When a mesh is too large to render in one batch, it will break into multiple meshes.
- Implement `dirty` bits for all buffers so that there is minimum` rebuild` overhead.
- Also moved all `rebuild` to right before render, as with dirty bits, there is no overhead.

![image](https://github.com/user-attachments/assets/8e68aa11-d34e-40b0-b59e-d5930f571a1f)

The rendered image is now correct even with `chunkSize=16`.

Side note: this commit assumes https://github.com/misode/deepslate/pull/55