### PR TITLE
Add player_head special model

### DIFF
--- a/src/render/SpecialModel.ts
+++ b/src/render/SpecialModel.ts
@@ -28,6 +28,11 @@ export namespace SpecialModel {
 				typeof root.texture === 'string' ? Identifier.parse(root.texture) : undefined,
 				Json.readNumber(root.animation) ?? 0
 			)
+			case 'player_head': return new Head(
+				'player',
+				undefined,
+				0
+			)
 			case 'shulker_box': return new ShulkerBox(
 				Identifier.parse(Json.readString(root.texture) ?? ''),
 				Json.readNumber(root.openness) ?? 0,


### PR DESCRIPTION
Adds the `player_head` special model added in 1.21.6-pre1. Since we don't handle custom skins anyways, we don't need any changes to the `head` special model.