### PR TITLE
A fix for heavy_core failing to get it's texture

### DIFF
--- a/src/render/BlockModel.ts
+++ b/src/render/BlockModel.ts
@@ -188,10 +188,16 @@ export class BlockModel {
 	}
 
 	private getTexture(textureRef: string) {
-		while (textureRef.startsWith('#')) {
-			textureRef = this.textures?.[textureRef.slice(1)] ?? ''
+		let currentRef = textureRef;
+		for (let i = 0; i < 7; i++) {
+			const key = currentRef.startsWith('#') ? currentRef.slice(1) : currentRef;
+			const nextRef = this.textures?.[key];
+			if (nextRef === undefined) {
+				break;
+			}
+			currentRef = nextRef;
 		}
-		return Identifier.parse(textureRef)
+		return Identifier.parse(currentRef)
 	}
 
 	public flatten(accessor: BlockModelProvider) {


### PR DESCRIPTION
Before:
![before](https://github.com/user-attachments/assets/f4f38e98-d050-47eb-8722-2f144d9b24bc)
After:
![after](https://github.com/user-attachments/assets/1d89bb28-3a27-4255-8e29-6c8d04ff2c34)

Currently the heavy_core model is falling back to the texture at 0, 0 on the texture atlas because it's trying to use "all" as a texture and that doesn't exist. The heavy core's block model has it's face's textures defined like `"texture": "all"` but they should be defined like `"texture": "#all"`. Without a '#' getTexture will skip the texture lookup for heavy_core.

I am not sure this is the best approach to solve this so let me know if you have a better idea. Added an extra check to make sure the textureRef string doesn't exist in this.textures before returning it. I put a cap of 7 on the loop out of an abundance of caution but it rarely reaches 3.  The other option I thought of would just be an explicit if === 'all' check to only catch this one case.

If Mojang fixes how they define the heavy_core model this would be unnecessary but as far as I can tell this is how they have defined it since they added the block.