### PR TITLE
Considering `AND` when parsing multipart

### DIFF
--- a/demo/main.ts
+++ b/demo/main.ts
@@ -1,6 +1,6 @@
 import { mat4 } from 'gl-matrix'
 import type { ItemRendererResources, ItemRenderingContext, NbtTag, Resources, Voxel } from '../src/index.js'
-import { BlockDefinition, BlockModel, Identifier, ItemRenderer, ItemStack, NormalNoise, Structure, StructureRenderer, TextureAtlas, VoxelRenderer, XoroshiroRandom, jsonToNbt, upperPowerOfTwo } from '../src/index.js'
+import { BlockDefinition, BlockModel, Identifier, ItemRenderer, ItemStack, jsonToNbt, NormalNoise, Structure, StructureRenderer, TextureAtlas, upperPowerOfTwo, VoxelRenderer, XoroshiroRandom } from '../src/index.js'
 import { } from '../src/nbt/Util.js'
 import { ItemModel } from '../src/render/ItemModel.js'
 
@@ -83,7 +83,7 @@ Promise.all([
 
 	const itemList = document.createElement('datalist')
 	itemList.id = 'item-list'
-	items.forEach(item => {
+	items.forEach((item: any) => {
 		const option = document.createElement('option')
 		option.textContent = item
 		itemList.append(option)
@@ -99,7 +99,7 @@ Promise.all([
 	Object.keys(models).forEach(id => {
 		blockModels['minecraft:' + id] = BlockModel.fromJson(models[id])
 	})
-	Object.values(blockModels).forEach((m: any) => m.flatten({ getBlockModel: id => blockModels[id] }))
+	Object.values(blockModels).forEach((m: any) => m.flatten({ getBlockModel: (id: any) => blockModels[id] }))
 
 
 	const itemModels: Record<string, ItemModel> = {}
@@ -123,7 +123,7 @@ Promise.all([
 	const atlasCtx = atlasCanvas.getContext('2d')!
 	atlasCtx.drawImage(atlas, 0, 0)
 	const atlasData = atlasCtx.getImageData(0, 0, atlasSize, atlasSize)
-	const idMap = {}
+	const idMap: Record<string, any> = {}
 	Object.keys(uvMap).forEach(id => {
 		const [u, v, du, dv] = uvMap[id]
 		const dv2 = (du !== dv && id.startsWith('block/')) ? du : dv

--- a/src/render/BlockDefinition.ts
+++ b/src/render/BlockDefinition.ts
@@ -18,7 +18,8 @@ type ModelVariantEntry = ModelVariant | (ModelVariant & {
 })[]
 
 type ModelMultiPartCondition = {
-	OR: ModelMultiPartCondition[],
+	OR?: ModelMultiPartCondition[],
+	AND?: ModelMultiPartCondition[],
 } | {
 	[key: string]: string,
 }
@@ -43,10 +44,10 @@ export class BlockDefinition {
 			const matches = Object.keys(this.variants).filter(v => this.matchesVariant(v, props))
 			if (matches.length === 0) return []
 			const variant = this.variants[matches[0]]
-			return [Array.isArray(variant) ? variant[0] : variant]
+			return [this.weightedApply(variant)]
 		} else if (this.multipart) {
 			const matches = this.multipart.filter(p => p.when ? this.matchesCase(p.when, props) : true)
-			return matches.map(p => Array.isArray(p.apply) ? p.apply[0] : p.apply) 
+			return matches.map(p => this.weightedApply(p.apply)) 
 		}
 		return []
 	}
@@ -80,6 +81,41 @@ export class BlockDefinition {
 		return mesh.transform(t)
 	}
 
+	private weightedApply(apply: ModelVariantEntry) {
+		if (Array.isArray(apply)) {
+			// Sets the probability of the model for being used in the game,
+			// defaults to 1 (=100%). If more than one model is used for the same
+			// variant, the probability is calculated by dividing the individual
+			// model's weight by the sum of the weights of all models.
+			// (For example, if three models are used with weights 1, 1, and 2,
+			// then their combined weight would be 4 (1+1+2). The probability of each
+			// model being used would then be determined by dividing each weight
+			// by 4: 1/4, 1/4 and 2/4, or 25%, 25% and 50%, respectively.)
+
+			const totalWeight: number = apply
+					.reduce((sum, entry) => sum + (entry.weight ?? 1), 0);
+			let r: number = Math.random() * totalWeight;
+
+			// Iterate through the entries, subtracting weight until we find the selected one
+			for (const entry of apply) {
+					const w: number = entry.weight ?? 1;
+					if (r < w) {
+							// Destructure to drop the weight property and return the variant
+							const { weight, ...variant }: { weight?: number } & ModelVariant = entry;
+							return variant;
+					}
+					r -= w;
+			}
+
+			// Fallback (due to floating-point edge cases): return the last variant
+			const lastEntry = apply[apply.length - 1];
+			const { weight, ...variant }: { weight?: number } & ModelVariant = lastEntry;
+			return variant;
+		} else {
+			return apply
+		}
+	}
+
 	private matchesVariant(variant: string, props: { [key: string]: string }): boolean {
 		return variant.split(',').every(p => {
 			const [k, v] = p.split('=')
@@ -88,9 +124,12 @@ export class BlockDefinition {
 	}
 
 	private matchesCase(condition: ModelMultiPartCondition, props: { [key: string]: string }): boolean {
-		if (Array.isArray(condition.OR)) {
+		if (condition.OR && Array.isArray(condition.OR)) {
 			return condition.OR.some(c => this.matchesCase(c, props))
+		} else if (condition.AND && Array.isArray(condition.AND)) {
+			return condition.AND.every(c => this.matchesCase(c, props))
 		}
+
 		const states = condition as {[key: string]: string}
 		return Object.keys(states).every(k => {
 			const values = states[k].split('|')

--- a/src/render/BlockDefinition.ts
+++ b/src/render/BlockDefinition.ts
@@ -44,10 +44,10 @@ export class BlockDefinition {
 			const matches = Object.keys(this.variants).filter(v => this.matchesVariant(v, props))
 			if (matches.length === 0) return []
 			const variant = this.variants[matches[0]]
-			return [this.weightedApply(variant)]
+			return [Array.isArray(variant) ? variant[0] : variant]
 		} else if (this.multipart) {
 			const matches = this.multipart.filter(p => p.when ? this.matchesCase(p.when, props) : true)
-			return matches.map(p => this.weightedApply(p.apply)) 
+			return matches.map(p => Array.isArray(p.apply) ? p.apply[0] : p.apply) 
 		}
 		return []
 	}
@@ -81,41 +81,6 @@ export class BlockDefinition {
 		return mesh.transform(t)
 	}
 
-	private weightedApply(apply: ModelVariantEntry) {
-		if (Array.isArray(apply)) {
-			// Sets the probability of the model for being used in the game,
-			// defaults to 1 (=100%). If more than one model is used for the same
-			// variant, the probability is calculated by dividing the individual
-			// model's weight by the sum of the weights of all models.
-			// (For example, if three models are used with weights 1, 1, and 2,
-			// then their combined weight would be 4 (1+1+2). The probability of each
-			// model being used would then be determined by dividing each weight
-			// by 4: 1/4, 1/4 and 2/4, or 25%, 25% and 50%, respectively.)
-
-			const totalWeight: number = apply
-					.reduce((sum, entry) => sum + (entry.weight ?? 1), 0);
-			let r: number = Math.random() * totalWeight;
-
-			// Iterate through the entries, subtracting weight until we find the selected one
-			for (const entry of apply) {
-					const w: number = entry.weight ?? 1;
-					if (r < w) {
-							// Destructure to drop the weight property and return the variant
-							const { weight, ...variant }: { weight?: number } & ModelVariant = entry;
-							return variant;
-					}
-					r -= w;
-			}
-
-			// Fallback (due to floating-point edge cases): return the last variant
-			const lastEntry = apply[apply.length - 1];
-			const { weight, ...variant }: { weight?: number } & ModelVariant = lastEntry;
-			return variant;
-		} else {
-			return apply
-		}
-	}
-
 	private matchesVariant(variant: string, props: { [key: string]: string }): boolean {
 		return variant.split(',').every(p => {
 			const [k, v] = p.split('=')
@@ -124,12 +89,11 @@ export class BlockDefinition {
 	}
 
 	private matchesCase(condition: ModelMultiPartCondition, props: { [key: string]: string }): boolean {
-		if (condition.OR && Array.isArray(condition.OR)) {
+		if (Array.isArray(condition.OR)) {
 			return condition.OR.some(c => this.matchesCase(c, props))
-		} else if (condition.AND && Array.isArray(condition.AND)) {
+		} else if (Array.isArray(condition.AND)) {
 			return condition.AND.every(c => this.matchesCase(c, props))
 		}
-
 		const states = condition as {[key: string]: string}
 		return Object.keys(states).every(k => {
 			const values = states[k].split('|')


### PR DESCRIPTION
This PR parses and executes variants' weights and `OR` in `condition` according to [wiki](https://minecraft.fandom.com/wiki/Tutorials/Models#Examples:_Condensing_multiple_textures_into_one_file). Note that I have not tested the correctness of this feature.