### PR TITLE
Support object-form texture references in block models (1.21.4+)

### DIFF
--- a/src/render/BlockModel.ts
+++ b/src/render/BlockModel.ts
@@ -21,6 +21,11 @@ type BlockModelFace = {
 	tintindex?: number,
 }
 
+export type TextureRef = string | {
+	sprite: string,
+	force_translucent?: boolean,
+}
+
 export type BlockModelElement = {
 	from: number[],
 	to: number[],
@@ -77,7 +82,7 @@ export class BlockModel {
 
 	constructor(
 		private parent: Identifier | undefined,
-		private textures: { [key: string]: string } | undefined,
+		private textures: { [key: string]: TextureRef } | undefined,
 		private elements: BlockModelElement[] | undefined,
 		private display?: BlockModelDisplay | undefined,
 		private guiLight?: BlockModelGuiLight | undefined,
@@ -189,11 +194,12 @@ export class BlockModel {
 
 	private getTexture(textureRef: string) {
 		textureRef = textureRef.startsWith('#') ? textureRef.slice(1) : textureRef
-		textureRef = this.textures?.[textureRef] ?? ''
-		while (textureRef.startsWith('#')) {
-			textureRef = this.textures?.[textureRef.slice(1)] ?? ''
+		let value: TextureRef = this.textures?.[textureRef] ?? ''
+		while (typeof value === 'string' && value.startsWith('#')) {
+			value = this.textures?.[value.slice(1)] ?? ''
 		}
-		return Identifier.parse(textureRef)
+		const sprite = typeof value === 'string' ? value : value.sprite
+		return Identifier.parse(sprite)
 	}
 
 	public flatten(accessor: BlockModelProvider) {

--- a/src/render/BlockModel.ts
+++ b/src/render/BlockModel.ts
@@ -195,11 +195,17 @@ export class BlockModel {
 	private getTexture(textureRef: string) {
 		textureRef = textureRef.startsWith('#') ? textureRef.slice(1) : textureRef
 		let value: TextureRef = this.textures?.[textureRef] ?? ''
-		while (typeof value === 'string' && value.startsWith('#')) {
+		let hops = this.textures ? Object.keys(this.textures).length : 0
+		while (hops-- > 0) {
+			if (typeof value !== 'string') {
+				value = value.sprite
+			}
+			if (!value.startsWith('#')) {
+				break
+			}
 			value = this.textures?.[value.slice(1)] ?? ''
 		}
-		const sprite = typeof value === 'string' ? value : value.sprite
-		return Identifier.parse(sprite)
+		return Identifier.parse(typeof value === 'string' ? value : value.sprite)
 	}
 
 	public flatten(accessor: BlockModelProvider) {

--- a/test/render/BlockModel.test.ts
+++ b/test/render/BlockModel.test.ts
@@ -53,4 +53,25 @@ describe('BlockModel', () => {
 		model.getMesh(collectingAtlas(requested), {})
 		expect(requested).toContain('minecraft:block/white_stained_glass')
 	})
+
+	it('resolves an object whose sprite is itself a reference', () => {
+		const requested: string[] = []
+		const model = BlockModel.fromJson({
+			...cube,
+			textures: {
+				all: { sprite: '#base', force_translucent: true },
+				base: 'minecraft:block/tinted_glass',
+			},
+		})
+		model.getMesh(collectingAtlas(requested), {})
+		expect(requested).toContain('minecraft:block/tinted_glass')
+	})
+
+	it('terminates on a cyclic reference instead of looping forever', () => {
+		const model = BlockModel.fromJson({
+			...cube,
+			textures: { all: '#a', a: '#b', b: '#a' },
+		})
+		expect(() => model.getMesh(collectingAtlas([]), {})).not.toThrow()
+	})
 })

--- a/test/render/BlockModel.test.ts
+++ b/test/render/BlockModel.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import type { Identifier } from '../../src'
+import { BlockModel } from '../../src'
+import type { TextureAtlasProvider, UV } from '../../src/render/TextureAtlas'
+
+describe('BlockModel', () => {
+	function collectingAtlas(requested: string[]): TextureAtlasProvider {
+		return {
+			getTextureUV(id: Identifier): UV {
+				requested.push(id.toString())
+				return [0, 0, 1, 1]
+			},
+			getTextureAtlas() {
+				return new ImageData(1, 1)
+			},
+		}
+	}
+
+	const cube = {
+		elements: [{
+			from: [0, 0, 0],
+			to: [16, 16, 16],
+			faces: { up: { texture: '#all' } },
+		}],
+	}
+
+	it('resolves a plain string texture reference', () => {
+		const requested: string[] = []
+		const model = BlockModel.fromJson({ ...cube, textures: { all: 'minecraft:block/stone' } })
+		model.getMesh(collectingAtlas(requested), {})
+		expect(requested).toContain('minecraft:block/stone')
+	})
+
+	it('resolves an object texture reference to its sprite (1.21.4+ format)', () => {
+		const requested: string[] = []
+		const model = BlockModel.fromJson({
+			...cube,
+			textures: { all: { sprite: 'minecraft:block/glass', force_translucent: true } },
+		})
+		model.getMesh(collectingAtlas(requested), {})
+		expect(requested).toContain('minecraft:block/glass')
+	})
+
+	it('follows a reference chain that ends in an object', () => {
+		const requested: string[] = []
+		const model = BlockModel.fromJson({
+			...cube,
+			textures: {
+				all: '#ref',
+				ref: { sprite: 'minecraft:block/white_stained_glass' },
+			},
+		})
+		model.getMesh(collectingAtlas(requested), {})
+		expect(requested).toContain('minecraft:block/white_stained_glass')
+	})
+})


### PR DESCRIPTION
Since 1.21.4, a block model's `textures` value can be an object
`{ "sprite": "...", "force_translucent": true }` instead of a bare path string
(e.g. glass, stained glass). `BlockModel.getTexture` assumed a string and failed
to resolve these, so those blocks rendered untextured.

This resolves the object form to its `sprite`. Backward compatible - the string
form is unchanged. Translucency is intentionally out of scope: deepslate derives
it from block flags (`getBlockFlags().semi_transparent`), not from the model, so
`force_translucent` is not wired into rendering here.

Adds test/render/BlockModel.test.ts (string ref, object ref, ref-chain in object).